### PR TITLE
wip: trying patch to fix FBX export

### DIFF
--- a/ports/assimp/bugfix_4686.patch
+++ b/ports/assimp/bugfix_4686.patch
@@ -1,0 +1,38 @@
+diff --git a/code/AssetLib/FBX/FBXExportNode.cpp b/code/AssetLib/FBX/FBXExportNode.cpp
+index 21c61b2..9cf863c 100644
+--- a/code/AssetLib/FBX/FBXExportNode.cpp
++++ b/code/AssetLib/FBX/FBXExportNode.cpp
+@@ -360,7 +360,7 @@ void FBX::Node::EndBinary(
+     bool has_children
+ ) {
+     // if there were children, add a null record
+-    if (has_children) { s.PutString(Assimp::FBX::NULL_RECORD); }
++    if (has_children) { s.PutString(Assimp::FBX::NULL_RECORD,Assimp::FBX::NumNullRecords); }
+ 
+     // now go back and write initial pos
+     this->end_pos = s.Tell();
+diff --git a/include/assimp/StreamWriter.h b/include/assimp/StreamWriter.h
+index 1bdfcc6..5f6e9d7 100644
+--- a/include/assimp/StreamWriter.h
++++ b/include/assimp/StreamWriter.h
+@@ -225,7 +225,19 @@ public:
+         ::memcpy(dest, s.C_Str(), s.length);
+         cursor += s.length;
+     }
+-
++    // ---------------------------------------------------------------------
++    /** Write an char array to the stream */
++    void PutString(const char *s, size_t size) {
++        if (size == 0)
++            return;
++        // as Put(T f) below
++        if (cursor + size >= buffer.size()) {
++            buffer.resize(cursor + size);
++        }
++        void *dest = &buffer[cursor];
++        ::memcpy(dest, s, size);
++        cursor += size;
++    }
+     // ---------------------------------------------------------------------
+     /** Write a std::string to the stream */
+     void PutString(const std::string& s)

--- a/ports/assimp/portfile.cmake
+++ b/ports/assimp/portfile.cmake
@@ -5,6 +5,7 @@ vcpkg_from_github(
     SHA512 ac0dc4243f9d1ff077966f0037187b4374075ac97e75e1a3cd6bdc1caf5f8e4d40953d9a8a316480969c09524d87daa9d3ed75e6ac6f037dd5b1c5f25fce3afb
     HEAD_REF master
     PATCHES
+        bugfix_4686.patch
         build_fixes.patch
 )
 


### PR DESCRIPTION
**Describe the pull request**
This applies a patch which a user posted to fix ASSIMP->FBX export bug: [4686](https://github.com/assimp/assimp/issues/4686)

- #### What does your PR fix?
  Fixes #[3412](https://app.shortcut.com/polycam/story/3412/exported-fbx-files-can-t-find-the-correct-texture)
